### PR TITLE
super if defined? super

### DIFF
--- a/lib/filewatcher/spinner.rb
+++ b/lib/filewatcher/spinner.rb
@@ -24,32 +24,32 @@ class Filewatcher
     end
 
     def before_pause_sleep
-      super
+      super if defined? super
       update_spinner('Paused')
     end
 
     def before_resume_sleep
-      super
+      super if defined? super
       update_spinner('Resumed')
     end
 
     def after_stop
-      super
+      super if defined? super
       update_spinner('Stopped')
     end
 
     def finalizing
-      super
+      super if defined? super
       update_spinner('Finalizing')
     end
 
     def before_pausing_sleep
-      super
+      super if defined? super
       update_spinner('Pausing')
     end
 
     def before_watching_sleep
-      super
+      super if defined? super
       update_spinner('Watching')
     end
 


### PR DESCRIPTION
```
/bundle/ruby/3.0.0/bundler/gems/filewatcher-spinner-9246172e955e/lib/filewatcher/spinner.rb:27:in `before_pause_sleep': super: no superclass method `before_pause_sleep' for #<Filewatcher:0x0000aaaaf3de3a70 @unexpanded_filenames="d2/src/**/*.{js,ts,tsx}", @unexpanded_excluded_filenames="d2/src/queries/*.*", @keep_watching=true, @pausing=true, @immediate=nil, @interval=1, @logger=#<Logger:0x0000aaaaf3de39f8 @level=1, @progname=nil, @default_formatter=#<Logger::Formatter:0x0000aaaaf3de3908 @datetime_format=nil>, @formatter=nil, @logdev=#<Logger::LogDevice:0x0000aaaaf3de37c8 @shift_period_suffix=nil, @shift_size=nil, @shift_age=nil, @filename=nil, @dev=#<IO:<STDOUT>>, @binmode=false, @mon_data=#<Monitor:0x0000aaaaf3de3750>, @mon_data_owner_object_id=13480>>, @show_spinner=true, @on_update=#<Proc:0x0000aaaaf3de2f08 d2/scripts/update-graphql-schema.rb:217>, @last_snapshot=#<Filewatcher::Snapshot:0x0000aaaaf6d554c0 @data={"/vydia/d2/src/@types/react-suspender.d.ts"=>#<Filewatcher::Snapshot::SnapshotFile:13520 (NoMethodError)
...
...
Did you mean?  before_pausing_sleep
               before_resume_sleep
	from /bundle/ruby/3.0.0/gems/filewatcher-2.0.0.beta5/lib/filewatcher.rb:109:in `before_pause_sleep'
	from /bundle/ruby/3.0.0/gems/filewatcher-2.0.0.beta5/lib/filewatcher.rb:58:in `pause'

```